### PR TITLE
Add assertions to handle unexpected errors

### DIFF
--- a/src/main/java/jarvis/tasks/Task.java
+++ b/src/main/java/jarvis/tasks/Task.java
@@ -34,6 +34,7 @@ public abstract class Task {
     public static Task of(String taskString) throws InvalidTaskException {
         Task task;
         String[] taskArr = taskString.split(" ", 2);
+        assert taskArr.length >= 1 : "Invalid taskArr";
         String taskType = taskArr[0];
         String[] params;
 


### PR DESCRIPTION
of method in the Task class: added an assertion to check that the
taskArr is larger or equals to 1

The variable taskType extracts the first value from the taskArr, hence
taskArr needs to have at least one element

By checking that the length of the taskArr is at least 1, it would never
reach the state where taskType has no value to extract from taskArr